### PR TITLE
fixed MCMC for multiple visits, applied "uncmulti_val" to error, added model "model_rowshift"

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -56,7 +56,7 @@ Instrument Systematics
 
 * `model_rowshift.py <https://pacmandocs.readthedocs.io/en/latest/_modules/pacman/lib/models/model_rowshift.html#model_rowshift>`_
 
-  Linear trend with shift of the spectrum on the detector in spatial direction (rows). Independent application for both scan directions. Implemented similarly to the method explained in `Tsiaras et al. (2016) <https://arxiv.org/pdf/1511.08901.pdf>`_.
+  Linear trend with shift of the spectrum on the detector in spatial direction (rows). Independent application for both scan directions. Implemented similarly to the method explained in `Tsiaras et al. (2016) <https://arxiv.org/pdf/1511.08901.pdf>`_. (free parameters: vf, vr)
 
 .. note:: Requires that stage 20 was executed with calculate_rowshift True.
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -54,6 +54,11 @@ Instrument Systematics
 
 .. note:: c is in log10. An average flux of 10^7 photoelectrons therefore leads to approximately c = 7.
 
+* `model_rowshift.py <https://pacmandocs.readthedocs.io/en/latest/_modules/pacman/lib/models/model_rowshift.html#model_rowshift>`_
+
+  Linear trend with shift of the spectrum on the detector in spatial direction (rows). Independent application for both scan directions. Implemented similarly to the method explained in `Tsiaras et al. (2016) <https://arxiv.org/pdf/1511.08901.pdf>`_.
+
+.. note:: Requires that stage 20 was executed with calculate_rowshift True.
 
 * `uncmulti.py <https://pacmandocs.readthedocs.io/en/latest/_modules/pacman/lib/models/uncmulti.html#uncmulti>`_
 

--- a/src/pacman/data/run_files/fit_par.txt
+++ b/src/pacman/data/run_files/fit_par.txt
@@ -13,7 +13,9 @@ ecc            True    -1     0.0         False    0.0       False    0.0      X
 c              False   0      8.37        True     6.0       True     8.9      X       6.7       7.0      0.001      
 c              False   1      8.37        True     6.0       True     8.9      X       6.7       7.0      0.001      
 v              False   0      -1e-06      False    -0.0001   False    -1e-08   X       -7e-06    -1e-06   1e-05      
-v              False   1      -1e-06      False    -0.0001   False    -1e-08   X       -7e-06    -1e-06   1e-05      
+v              False   1      -1e-06      False    -0.0001   False    -1e-08   X       -7e-06    -1e-06   1e-05
+rowshift_vr    False   -1     0.0         False    -10.0     False    10.0     U       -1.0      1.0      1e-07      
+rowshift_vf    False   -1     0.0         False    -10.0     False    10.0     U       -1.0      1.0      1e-07       
 v2             True    -1     0.0         True     0.0       True     1.0      X       0.0       0.0      1e-11      
 r1             False   0      0.1         False    0.0       False    1.0      U       -10.0     10.0     0.01       
 r1             False   1      0.1         False    0.0       False    1.0      U       -10.0     10.0     0.01       

--- a/src/pacman/data/run_files/obs_par.pcf
+++ b/src/pacman/data/run_files/obs_par.pcf
@@ -69,6 +69,14 @@ bg_rmax                      400
 bg_cmin                      40
 bg_cmax                      100
 
+calculate_rowshift           False                                             # calculates spatial shift of spectrum on detector with respect to first exposure
+
+save_rowshift_plot           False                                             # save plot of rowshift fit
+show_rowshift_plot           False
+
+save_rowshift_stretch_plot   False                                             # save plot of stretch fit and plot of profile stretch to rowshift
+show_rowshift_stretch_plot   False
+
 save_optextr_plot            True
 
 save_sp2d_plot               True                                              # save plot of 2d spectrum

--- a/src/pacman/lib/formatter.py
+++ b/src/pacman/lib/formatter.py
@@ -45,6 +45,9 @@ class FormatParams:
             self.r3 = params[data.par_order['r3']*data.nvisit:(1 + data.par_order['r3'])*data.nvisit]
         elif 'upstream_downstream' in data.s30_myfuncs:
             self.scale = params[data.par_order['scale']*data.nvisit:(1 + data.par_order['scale'])*data.nvisit]
+        elif 'model_rowshift' in data.s30_myfuncs:
+            self.rowshift_vf = params[data.par_order['rowshift_vf']*data.nvisit:(1 + data.par_order['rowshift_vf'])*data.nvisit]
+            self.rowshift_vr = params[data.par_order['rowshift_vr']*data.nvisit:(1 + data.par_order['rowshift_vr'])*data.nvisit]
         elif 'ackbar' in data.s30_myfuncs:
             self.trap_pop_s = params[data.par_order['trap_pop_s']*data.nvisit:(1 + data.par_order['trap_pop_s'])*data.nvisit]
             self.trap_pop_f = params[data.par_order['trap_pop_f']*data.nvisit:(1 + data.par_order['trap_pop_f'])*data.nvisit]

--- a/src/pacman/lib/functions.py
+++ b/src/pacman/lib/functions.py
@@ -17,6 +17,7 @@ from ..lib.models.gp_sho import gp_sho
 from ..lib.models.gp_matern32 import gp_matern32
 from ..lib.models.constants_cj import constants_cj
 from ..lib.models.uncmulti import uncmulti
+from ..lib.models.model_rowshift import model_rowshift
 
 sys.path.insert(0, './models')
 
@@ -38,6 +39,12 @@ class Functions:
             elif f == "upstream_downstream":
                 self.sys.append(upstream_downstream)
                 self.sys_porder.append([data.par_order['scale']*data.nvisit])
+            elif f == "model_rowshift":
+                self.sys.append(model_rowshift)
+                self.sys_porder.append([
+                    data.par_order['rowshift_vf']*data.nvisit,
+                    data.par_order['rowshift_vr']*data.nvisit
+                ])
             elif f == "polynomial1":
                 self.sys.append(polynomial1)
                 self.sys_porder.append([data.par_order['v']*data.nvisit])

--- a/src/pacman/lib/mcmc.py
+++ b/src/pacman/lib/mcmc.py
@@ -92,6 +92,8 @@ def mcmc_fit(data, model, params, file_name, meta, fit_par):
             print(f'{row[3]: >8}: {row[1]: >24} {row[0]: >24} {row[2]: >24} ', file=f_mcmc)
 
     updated_params = util.format_params_for_Model(medians, params, nvisit, fixed_array, tied_array, free_array, untied_array)
+    if 'uncmulti' in data.s30_myfuncs:
+        data.err = updated_params[-1] * data.err_notrescaled
     fit = model.fit(data, updated_params)
     util.append_fit_output(fit, meta, fitter='mcmc', medians=medians)
 

--- a/src/pacman/lib/mcmc.py
+++ b/src/pacman/lib/mcmc.py
@@ -26,7 +26,8 @@ def mcmc_fit(data, model, params, file_name, meta, fit_par):
     fixed_array = np.array(fit_par['fixed'])
     tied_array = np.array(fit_par['tied'])
     free_array = util.return_free_array(nvisit, fixed_array, tied_array)
-    l_args = [params, data, model, nvisit, fixed_array, tied_array, free_array]
+    untied_array = util.return_untied_array(nvisit, fixed_array, tied_array)
+    l_args = [params, data, model, nvisit, fixed_array, tied_array, free_array, untied_array]
 
     # Setting up multiprocessing
     if hasattr(meta, 'ncpu') and meta.ncpu > 1:
@@ -90,7 +91,7 @@ def mcmc_fit(data, model, params, file_name, meta, fit_par):
         for row in zip(errors_lower, medians, errors_upper, labels):
             print(f'{row[3]: >8}: {row[1]: >24} {row[0]: >24} {row[2]: >24} ', file=f_mcmc)
 
-    updated_params = util.format_params_for_Model(medians, params, nvisit, fixed_array, tied_array, free_array)
+    updated_params = util.format_params_for_Model(medians, params, nvisit, fixed_array, tied_array, free_array, untied_array)
     fit = model.fit(data, updated_params)
     util.append_fit_output(fit, meta, fitter='mcmc', medians=medians)
 
@@ -136,9 +137,9 @@ def lnprior(theta, data):
     return lnprior_prob
 
 
-def lnprob(theta, params, data, model, nvisit, fixed_array, tied_array, free_array):
+def lnprob(theta, params, data, model, nvisit, fixed_array, tied_array, free_array, untied_array):
     """Calculates the log-likelihood."""
-    updated_params = util.format_params_for_Model(theta, params, nvisit, fixed_array, tied_array, free_array)
+    updated_params = util.format_params_for_Model(theta, params, nvisit, fixed_array, tied_array, free_array, untied_array)
     if 'uncmulti' in data.s30_myfuncs:
         data.err = updated_params[-1] * data.err_notrescaled
     lp = lnprior(theta, data)

--- a/src/pacman/lib/models/model_rowshift.py
+++ b/src/pacman/lib/models/model_rowshift.py
@@ -1,7 +1,7 @@
 import sys
 sys.path.insert(0,'..')
 
-def model_rowshift(t, data, params, visit = 0):
+def model_rowshift(t, data, params, visit):
     rowshift_vf, rowshift_vr = params
     rowshift_vf = rowshift_vf[visit]#slope for forward scans
     rowshift_vr = rowshift_vr[visit]#slope for reverse scans

--- a/src/pacman/lib/models/model_rowshift.py
+++ b/src/pacman/lib/models/model_rowshift.py
@@ -1,0 +1,10 @@
+import sys
+sys.path.insert(0,'..')
+
+def model_rowshift(t, data, params, visit = 0):
+    rowshift_vf, rowshift_vr = params
+    rowshift_vf = rowshift_vf[visit]#slope for forward scans
+    rowshift_vr = rowshift_vr[visit]#slope for reverse scans
+
+    return 1 + rowshift_vr*data.rowshift[data.vis_idx[visit]]*data.scan_direction[data.vis_idx[visit]] \
+             + rowshift_vf*data.rowshift[data.vis_idx[visit]]*(1-data.scan_direction[data.vis_idx[visit]])

--- a/src/pacman/lib/nested.py
+++ b/src/pacman/lib/nested.py
@@ -113,6 +113,8 @@ def nested_sample(data, model, params, file_name, meta, fit_par):
                   '{0: >24} '.format(row[0]), '{0: >24} '.format(row[2]), file=f_mcmc)
 
     updated_params = util.format_params_for_Model(medians, params, nvisit, fixed_array, tied_array, free_array, untied_array)
+    if 'uncmulti' in data.s30_myfuncs:
+        data.err = updated_params[-1] * data.err_notrescaled
     fit = model.fit(data, updated_params)
     util.append_fit_output(fit, meta, fitter='nested', medians=medians)
 

--- a/src/pacman/lib/nested.py
+++ b/src/pacman/lib/nested.py
@@ -41,7 +41,8 @@ def nested_sample(data, model, params, file_name, meta, fit_par):
     fixed_array = np.array(fit_par['fixed'])
     tied_array = np.array(fit_par['tied'])
     free_array = util.return_free_array(nvisit, fixed_array, tied_array)
-    l_args = [params, data, model, nvisit, fixed_array, tied_array, free_array]
+    untied_array = util.return_untied_array(nvisit, fixed_array, tied_array)
+    l_args = [params, data, model, nvisit, fixed_array, tied_array, free_array, untied_array]
     p_args = [data]
 
     # Setting up multiprocessing
@@ -111,7 +112,7 @@ def nested_sample(data, model, params, file_name, meta, fit_par):
             print('{0: >8}: '.format(row[3]), '{0: >24} '.format(row[1]),
                   '{0: >24} '.format(row[0]), '{0: >24} '.format(row[2]), file=f_mcmc)
 
-    updated_params = util.format_params_for_Model(medians, params, nvisit, fixed_array, tied_array, free_array)
+    updated_params = util.format_params_for_Model(medians, params, nvisit, fixed_array, tied_array, free_array, untied_array)
     fit = model.fit(data, updated_params)
     util.append_fit_output(fit, meta, fitter='nested', medians=medians)
 
@@ -142,9 +143,9 @@ def ptform(u, data):
 
 
 def loglike(x, params, data, model, nvisit,
-            fixed_array, tied_array, free_array):
+            fixed_array, tied_array, free_array, untied_array):
     """Calculates the log-likelihood."""
-    updated_params = util.format_params_for_Model(x, params, nvisit, fixed_array, tied_array, free_array)
+    updated_params = util.format_params_for_Model(x, params, nvisit, fixed_array, tied_array, free_array, untied_array)
     if 'uncmulti' in data.s30_myfuncs:
         data.err = updated_params[-1] * data.err_notrescaled
     fit = model.fit(data, updated_params)

--- a/src/pacman/lib/plots.py
+++ b/src/pacman/lib/plots.py
@@ -732,6 +732,87 @@ def utr_aper_evo(peaks_all, meta):
         gc.collect()
 
 
+def rowshift_fit(modelx, modely, datax, datay, leastsq_res, meta, i):
+    fig, ax = plt.subplots(1,1, figsize=(9,6))
+    plt.suptitle('rowshift_fit {0}, visit {1}, orbit {2}'.format(i, meta.ivisit_sp[i], meta.iorbit_sp[i]))
+    ax.plot(modelx, modely/max(modely), label='first exposure')
+    ax.plot((leastsq_res[0] + datax), datay/max(datay),
+             label='profile fit = ({0:.5g}+x)*{1:.5g}'.format(leastsq_res[0],leastsq_res[1]))
+    ax.plot(datax, datay/max(datay), label='profile before fit')
+    peakx = modelx[np.argmax(modely)]
+    ax.set_xlim(peakx-20, peakx+20)
+    ax.set_xlabel('row / px')
+    ax.set_ylabel('rel. Flux')
+    plt.legend()
+    plt.tight_layout()
+    if meta.save_rowshift_plot:
+        if not os.path.isdir(meta.workdir + '/figs/s20_rowshift/'):
+            os.makedirs(meta.workdir + '/figs/s20_rowshift/')
+        plt.savefig(meta.workdir + '/figs/s20_rowshift/rowshift_{0}.png'.format(i), bbox_inches='tight', pad_inches=0.05, dpi=120)
+        plt.close('all')
+        plt.clf()
+        gc.collect()
+    else:
+        plt.show()
+        plt.close('all')
+        plt.clf()
+        gc.collect()
+
+
+def stretch_fit(modelx, modely, datax, datay, leastsq_res, meta, i):
+    fig, ax = plt.subplots(1,1, figsize=(9,6))
+    plt.suptitle('length_fit {0}, visit {1}, orbit {2}'.format(i, meta.ivisit_sp[i], meta.iorbit_sp[i]))
+    ax.plot(modelx, modely/max(modely), label='first exposure')
+    ax.plot((leastsq_res[0] + leastsq_res[1]*datax), datay/max(datay),
+             label='profile fit = ({0:.5g}+x*{1:.5g})*{2:.5g}'.format(leastsq_res[0],leastsq_res[1],leastsq_res[2]))
+    ax.plot(datax, datay/max(datay), label='profile before fit')
+    ax.set_xlabel('row / px')
+    ax.set_ylabel('rel. Flux')
+    plt.legend()
+    plt.tight_layout()
+    if save_rowshift_stretch_plot:
+        if not os.path.isdir(meta.workdir + '/figs/s20_stretch/'):
+            os.makedirs(meta.workdir + '/figs/s20_stretch/')
+        plt.savefig(meta.workdir + '/figs/s20_stretch/stretch_{0}.png'.format(i), bbox_inches='tight', pad_inches=0.05, dpi=120)
+        plt.close('all')
+        plt.clf()
+        gc.collect()
+    else:
+        plt.show()
+        plt.close('all')
+        plt.clf()
+        gc.collect()
+
+
+def rowshift_stretch(meta):
+    fig, ax = plt.subplots(1,1, figsize=(9,6))
+    marker_iterator = cycle(['o','^','s','v','D','x','2','<','>'])
+    color_iterator1 = cycle(['tab:blue','tab:cyan','tab:green','tab:olive'])
+    color_iterator2 = cycle(['tab:orange','tab:red','tab:brown','tab:pink'])
+    for visit_plot in set(meta.ivisit_sp):
+        marker = next(marker_iterator)
+        if (visit_plot%9) == 0:
+            color1=next(color_iterator1)
+            color2=next(color_iterator2)
+        ax.scatter(meta.rowshift[(meta.scans_sp==0) & (meta.ivisit_sp==visit_plot)], meta.stretch[(meta.scans_sp==0) & (meta.ivisit_sp==visit_plot)], marker=marker, color=color1, label='forward, visit {0}'.format(visit_plot))
+        ax.scatter(meta.rowshift[(meta.scans_sp==1) & (meta.ivisit_sp==visit_plot)], meta.stretch[(meta.scans_sp==1) & (meta.ivisit_sp==visit_plot)], marker=marker, color=color2, label='reverse, visit {0}'.format(visit_plot))
+    ax.set_xlabel('rowshift / px')
+    ax.set_ylabel('Stretch Scaling Factor')
+    plt.legend(fontsize="xx-small")
+    if meta.save_rowshift_stretch_plot:
+        if not os.path.isdir(meta.workdir + '/figs/s20_rowshift_stretch/'):
+            os.makedirs(meta.workdir + '/figs/s20_rowshift_stretch/')
+        plt.savefig(meta.workdir + '/figs/s20_rowshift_stretch/rowshift_stretch.png', bbox_inches='tight', pad_inches=0.05, dpi=120)
+        plt.close('all')
+        plt.clf()
+        gc.collect()
+    else:
+        plt.show()
+        plt.close('all')
+        plt.clf()
+        gc.collect()
+
+
 def refspec_fit(modelx, modely, p0, datax, datay, leastsq_res, meta, i):
     fig, ax = plt.subplots(1, 1, figsize=(9, 6))
     plt.suptitle(f'refspec_fit {i}, visit {meta.ivisit_sp[i]}, orbit {meta.iorbit_sp[i]}')

--- a/src/pacman/lib/plots.py
+++ b/src/pacman/lib/plots.py
@@ -746,9 +746,11 @@ def rowshift_fit(modelx, modely, datax, datay, leastsq_res, meta, i):
     plt.legend()
     plt.tight_layout()
     if meta.save_rowshift_plot:
-        if not os.path.isdir(meta.workdir + '/figs/s20_rowshift/'):
-            os.makedirs(meta.workdir + '/figs/s20_rowshift/')
-        plt.savefig(meta.workdir + '/figs/s20_rowshift/rowshift_{0}.png'.format(i), bbox_inches='tight', pad_inches=0.05, dpi=120)
+        s20_rowshift_dir = meta.workdir / 'figs' / 's20_rowshift'
+        if not s20_rowshift_dir.exists():
+            s20_rowshift_dir.mkdir(parents=True)
+        plt.savefig(s20_rowshift_dir / f'rowshift_{i}.png',
+                    bbox_inches='tight', pad_inches=0.05, dpi=120)
         plt.close('all')
         plt.clf()
         gc.collect()
@@ -770,10 +772,12 @@ def stretch_fit(modelx, modely, datax, datay, leastsq_res, meta, i):
     ax.set_ylabel('rel. Flux')
     plt.legend()
     plt.tight_layout()
-    if save_rowshift_stretch_plot:
-        if not os.path.isdir(meta.workdir + '/figs/s20_stretch/'):
-            os.makedirs(meta.workdir + '/figs/s20_stretch/')
-        plt.savefig(meta.workdir + '/figs/s20_stretch/stretch_{0}.png'.format(i), bbox_inches='tight', pad_inches=0.05, dpi=120)
+    if meta.save_rowshift_stretch_plot:        
+        s20_stretch_dir = meta.workdir / 'figs' / 's20_stretch'
+        if not s20_stretch_dir.exists():
+            s20_stretch_dir.mkdir(parents=True)
+        plt.savefig(s20_stretch_dir / f'stretch_{i}.png',
+                    bbox_inches='tight', pad_inches=0.05, dpi=120)
         plt.close('all')
         plt.clf()
         gc.collect()
@@ -786,23 +790,24 @@ def stretch_fit(modelx, modely, datax, datay, leastsq_res, meta, i):
 
 def rowshift_stretch(meta):
     fig, ax = plt.subplots(1,1, figsize=(9,6))
-    marker_iterator = cycle(['o','^','s','v','D','x','2','<','>'])
-    color_iterator1 = cycle(['tab:blue','tab:cyan','tab:green','tab:olive'])
-    color_iterator2 = cycle(['tab:orange','tab:red','tab:brown','tab:pink'])
+    marker_iterator = np.array(['o','^','s','v','D','x','2','<','>'])
+    color_iterator1 = np.array(['tab:blue','tab:cyan','tab:green','tab:olive'])
+    color_iterator2 = np.array(['tab:orange','tab:red','tab:brown','tab:pink'])
     for visit_plot in set(meta.ivisit_sp):
-        marker = next(marker_iterator)
-        if (visit_plot%9) == 0:
-            color1=next(color_iterator1)
-            color2=next(color_iterator2)
+        marker = marker_iterator[visit_plot%len(marker_iterator)]
+        color1 = color_iterator1[int(visit_plot/len(marker_iterator))]
+        color2 = color_iterator2[int(visit_plot/len(marker_iterator))]
         ax.scatter(meta.rowshift[(meta.scans_sp==0) & (meta.ivisit_sp==visit_plot)], meta.stretch[(meta.scans_sp==0) & (meta.ivisit_sp==visit_plot)], marker=marker, color=color1, label='forward, visit {0}'.format(visit_plot))
         ax.scatter(meta.rowshift[(meta.scans_sp==1) & (meta.ivisit_sp==visit_plot)], meta.stretch[(meta.scans_sp==1) & (meta.ivisit_sp==visit_plot)], marker=marker, color=color2, label='reverse, visit {0}'.format(visit_plot))
     ax.set_xlabel('rowshift / px')
     ax.set_ylabel('Stretch Scaling Factor')
     plt.legend(fontsize="xx-small")
     if meta.save_rowshift_stretch_plot:
-        if not os.path.isdir(meta.workdir + '/figs/s20_rowshift_stretch/'):
-            os.makedirs(meta.workdir + '/figs/s20_rowshift_stretch/')
-        plt.savefig(meta.workdir + '/figs/s20_rowshift_stretch/rowshift_stretch.png', bbox_inches='tight', pad_inches=0.05, dpi=120)
+        s20_rowshift_stretch_dir = meta.workdir / 'figs' / 's20_rowshift_stretch'
+        if not s20_rowshift_stretch_dir.exists():
+            s20_rowshift_stretch_dir.mkdir(parents=True)
+        plt.savefig(s20_rowshift_stretch_dir / f'rowshift_stretch.png',
+                    bbox_inches='tight', pad_inches=0.05, dpi=120)
         plt.close('all')
         plt.clf()
         gc.collect()

--- a/src/pacman/lib/read_data.py
+++ b/src/pacman/lib/read_data.py
@@ -213,7 +213,7 @@ class Data:
         if ('divide_white' in meta.s30_myfuncs) and meta.s30_fit_spec:
             self.white_systematics = np.genfromtxt(meta.white_sys_path)
         if meta.calculate_rowshift and ('model_rowshift' in meta.s30_myfuncs):
-            self.rowshift = rowshift[clip_mask]    
+            self.rowshift = rowshift[clip_mask]
         self.rescale_uncert = meta.rescale_uncert
 
 

--- a/src/pacman/lib/read_data.py
+++ b/src/pacman/lib/read_data.py
@@ -77,6 +77,41 @@ class Data:
         else:
             print('Leaving the first orbit in every visit.')
 
+        #####################################
+        # repeat previous steps for rowshift if model_rowshift is needed
+        if meta.calculate_rowshift and ('model_rowshift' in meta.s30_myfuncs):
+            # read in data
+            rowshift = meta.rowshift
+            # Remove first exposure from each orbit:
+            if meta.remove_first_exp:
+                leave_ind = np.ones(len(rowshift), bool)
+                leave_ind[meta.new_orbit_idx_sp] = False
+                rowshift = rowshift[leave_ind]
+                print(f'Removed {sum(~leave_ind)} exposures from rowshift because they were the first exposures in the orbit.')
+            else:
+                print('Leaving the first exposures from rowshift in every orbit.')
+            #
+            # Remove first or chosen orbit of each visit:
+            if len(meta.remove_which_orb) == 1:
+            # Removes first orbit
+                if meta.remove_first_orb:
+                    leave_ind = meta.iorbit_sp != 0
+                    rowshift = rowshift[leave_ind]
+                    print(f'Removed {sum(~leave_ind)} exposures from rowshift because they were the first orbit in the visit.')
+            elif len(meta.remove_which_orb) != 1 and meta.remove_first_orb:
+            # Removes chosen orbits from each orbit
+                if meta.remove_first_orb:
+                    masks_orb = []
+                    for i in range(len(meta.remove_which_orb)):
+                        masks_orb.append(meta.iorbit_sp != meta.remove_which_orb[i])
+                    leave_ind = np.bitwise_and(*masks_orb)
+                    rowshift = rowshift[leave_ind]
+                    print(f'Removed {sum(~leave_ind)} exposures from rowshift because they were the first orbit in the visit.')
+            else:
+                print('Leaving the first orbit of rowshift in every visit.')
+        elif ('model_rowshift' in meta.s30_myfuncs) and not meta.calculate_rowshift:
+            print('Please check if you ran s20 with "calculate_rowshift True". If not, you need to rerun s20 with this parameter on True in order to use "model_rowshift".')
+
         n = len(d)
 
         # t_delay will = 1 if it's the first orbit in a visit. Otherwise = 0
@@ -189,6 +224,8 @@ class Data:
         for i in range(nvisit): self.vis_idx.append(self.vis_num == i)
         if ('divide_white' in meta.s30_myfuncs) and meta.s30_fit_spec:
             self.white_systematics = np.genfromtxt(meta.white_sys_path)
+        if meta.calculate_rowshift and ('model_rowshift' in meta.s30_myfuncs):
+            self.rowshift = rowshift[clip_mask]    
         self.rescale_uncert = meta.rescale_uncert
 
 

--- a/src/pacman/lib/read_data.py
+++ b/src/pacman/lib/read_data.py
@@ -84,29 +84,17 @@ class Data:
             rowshift = meta.rowshift
             # Remove first exposure from each orbit:
             if meta.remove_first_exp:
-                leave_ind = np.ones(len(rowshift), bool)
-                leave_ind[meta.new_orbit_idx_sp] = False
-                rowshift = rowshift[leave_ind]
-                print(f'Removed {sum(~leave_ind)} exposures from rowshift because they were the first exposures in the orbit.')
+                leave_ind_r = np.ones(len(rowshift), bool) #remove first exposure without overwriting previously calculated orbit-mask
+                leave_ind_r[meta.new_orbit_idx_sp] = False
+                rowshift = rowshift[leave_ind_r]
+                print(f'Removed {sum(~leave_ind_r)} exposures from rowshift because they were the first exposures in the orbit.')
             else:
                 print('Leaving the first exposures from rowshift in every orbit.')
             #
-            # Remove first or chosen orbit of each visit:
-            if len(meta.remove_which_orb) == 1:
-            # Removes first orbit
-                if meta.remove_first_orb:
-                    leave_ind = meta.iorbit_sp != 0
-                    rowshift = rowshift[leave_ind]
-                    print(f'Removed {sum(~leave_ind)} exposures from rowshift because they were the first orbit in the visit.')
-            elif len(meta.remove_which_orb) != 1 and meta.remove_first_orb:
-            # Removes chosen orbits from each orbit
-                if meta.remove_first_orb:
-                    masks_orb = []
-                    for i in range(len(meta.remove_which_orb)):
-                        masks_orb.append(meta.iorbit_sp != meta.remove_which_orb[i])
-                    leave_ind = np.bitwise_and(*masks_orb)
-                    rowshift = rowshift[leave_ind]
-                    print(f'Removed {sum(~leave_ind)} exposures from rowshift because they were the first orbit in the visit.')
+            # Remove first or chosen orbit of each visit (leave_ind is unchanged from above):
+            if meta.remove_first_orb:
+                rowshift = rowshift[leave_ind]
+                print(f'Removed {sum(~leave_ind)} exposures from rowshift because they were the first orbit in the visit.')
             else:
                 print('Leaving the first orbit of rowshift in every visit.')
         elif ('model_rowshift' in meta.s30_myfuncs) and not meta.calculate_rowshift:

--- a/src/pacman/lib/util.py
+++ b/src/pacman/lib/util.py
@@ -629,9 +629,26 @@ def return_free_array(nvisit, fixed_array, tied_array):
     free_array = np.array(free_array)
     return free_array
 
+def return_untied_array(nvisit, fixed_array, tied_array):
+    """Reads in the fit_par.txt and determines which parameters are untied."""
+    untied_array = []
+    for i in range(len(fixed_array)):
+        if fixed_array[i].lower() == 'true' and tied_array[i] == -1:
+            for ii in range(nvisit):
+                untied_array.append(False)
+        if fixed_array[i].lower() == 'true' and not tied_array[i] == -1:
+            untied_array.append(True)
+        if fixed_array[i].lower() == 'false' and tied_array[i] == -1:
+            untied_array.append(False)
+            for ii in range(nvisit-1):
+                untied_array.append(False)
+        if fixed_array[i].lower() == 'false' and not tied_array[i] == -1:
+            untied_array.append(True)
+    untied_array = np.array(untied_array)
+    return untied_array
 
 def format_params_for_Model(theta, params, nvisit,
-                            fixed_array, tied_array, free_array):
+                            fixed_array, tied_array, free_array, untied_array):
     nvisit = int(nvisit)
     params_updated = []
 
@@ -648,9 +665,14 @@ def format_params_for_Model(theta, params, nvisit,
     #     array_new2 = np.array([item for sublist in array_new for item in sublist])
     #     return array_new2
 
+    #new function that copies parameters of visit 0 in visits>0 if tied=-1.:
     theta_new = np.copy(theta)
     params_updated = np.copy(params)
     params_updated[free_array] = theta_new
+    for i_p in range(0,len(untied_array), nvisit):
+        if not untied_array[i_p]:
+            for ii_p in range(1,nvisit):
+                params_updated[i_p+ii_p] = params_updated[i_p]
     # print('free_array', free_array)
     # print('params_updated', params_updated)
     return np.array(params_updated)
@@ -764,15 +786,15 @@ def weighted_mean(data, err):
 
 def create_res_dir(meta):
     """Creates the result directory depending on which fitters were used."""
-    print('H11', meta.workdir)
-    print('H22', meta.fitdir)
+    #print('H11', meta.workdir)
+    #print('H22', meta.fitdir)
 
     lsq_res_dir = meta.workdir / meta.fitdir / 'lsq_res'
-    print('H33', lsq_res_dir)
-    print('DOES IT EXIST', lsq_res_dir.exists())
+    #print('H33', lsq_res_dir)
+    #print('DOES IT EXIST', lsq_res_dir.exists())
     if not lsq_res_dir.exists():
         lsq_res_dir.mkdir(parents=True)
-    print('DOES THIS STILL RUN?')
+    #print('DOES THIS STILL RUN?')
     mcmc_res_dir = meta.workdir / meta.fitdir / 'mcmc_res'
     nested_res_dir = meta.workdir / meta.fitdir / 'nested_res'
     if meta.run_lsq:

--- a/src/pacman/lib/util.py
+++ b/src/pacman/lib/util.py
@@ -406,7 +406,7 @@ def get_boxspat(meta,i,d,rmin,rmax,cmin,cmax,imageIndex):#,x_ref, y_ref,x_data, 
     r_array = np.linspace(rmin,rmax+1,rmax-rmin) #array with row indexes
     spat_box_0_first = spat_box_0_first/np.nanmax(spat_box_0_first)
     
-    r_array = r_array[~np.isnan(s_opt_0)]
+    r_array = r_array[~np.isnan(spat_box_0_first)]
     spat_box_0_first = spat_box_0_first[~np.isnan(spat_box_0_first)]
     
     # NOTE: interpolate spectrum for fit
@@ -427,7 +427,7 @@ def calculate_stretch(meta,x_ref, y_ref,x_data, y_data,i):
     #all np arrays f(a+b*x2)*c
     p0 = [0,1,1]  # initial guess for least squares
     leastsq_res = leastsq(residuals2, p0, args=(x_ref, y_ref,x_data, y_data))[0]
-    if meta.save_rowshift_stretch_plot or show_rowshift_stretch_plot: 
+    if meta.save_rowshift_stretch_plot or meta.show_rowshift_stretch_plot:
         plots.stretch_fit(x_ref, y_ref, p0, x_data, y_data, leastsq_res, meta,i)
     return leastsq_res[1]#float
 

--- a/src/pacman/lib/util.py
+++ b/src/pacman/lib/util.py
@@ -428,7 +428,7 @@ def calculate_stretch(meta,x_ref, y_ref,x_data, y_data,i):
     p0 = [0,1,1]  # initial guess for least squares
     leastsq_res = leastsq(residuals2, p0, args=(x_ref, y_ref,x_data, y_data))[0]
     if meta.save_rowshift_stretch_plot or meta.show_rowshift_stretch_plot:
-        plots.stretch_fit(x_ref, y_ref, p0, x_data, y_data, leastsq_res, meta,i)
+        plots.stretch_fit(x_ref, y_ref, x_data, y_data, leastsq_res, meta,i)
     return leastsq_res[1]#float
 
 def correct_wave_shift_fct_0(meta, orbnum, cmin, cmax, spec_opt, i):

--- a/src/pacman/s00_table.py
+++ b/src/pacman/s00_table.py
@@ -78,7 +78,6 @@ def run00(eventlabel: str, pcf_path: Optional[Path] = Path.cwd()):
         Written by Sebastian Zieba      December 2021
     """
     print('\nStarting s00')
-    print('TEST: am I on the correct branch? If I see this - YES')
     # Initialize metadata object
     meta = MetaClass()
     meta.eventlabel = eventlabel

--- a/src/pacman/s00_table.py
+++ b/src/pacman/s00_table.py
@@ -15,7 +15,7 @@ from .lib import util
 from .lib import manageevent as me
 from .lib import plots
 
-
+#test
 class MetaClass:
     """A Class which will contain all the metadata of the analysis."""
     def __init__(self):

--- a/src/pacman/s00_table.py
+++ b/src/pacman/s00_table.py
@@ -15,7 +15,7 @@ from .lib import util
 from .lib import manageevent as me
 from .lib import plots
 
-#test
+
 class MetaClass:
     """A Class which will contain all the metadata of the analysis."""
     def __init__(self):

--- a/src/pacman/s00_table.py
+++ b/src/pacman/s00_table.py
@@ -78,7 +78,7 @@ def run00(eventlabel: str, pcf_path: Optional[Path] = Path.cwd()):
         Written by Sebastian Zieba      December 2021
     """
     print('\nStarting s00')
-
+    print('TEST: am I on the correct branch? If I see this - YES')
     # Initialize metadata object
     meta = MetaClass()
     meta.eventlabel = eventlabel

--- a/src/pacman/s20_extract.py
+++ b/src/pacman/s20_extract.py
@@ -185,7 +185,7 @@ def run20(eventlabel, workdir: Path, meta=None):
             # NOTE: If needed: Calculate spectrum shift in spatial direction (rows) with respect to the first exposure in the data-set (i.e. first visit, first orbit, first exposure)
             if meta.calculate_rowshift:
                 #get spatial profile of exposure of first readout
-                row_spat, flux_spat = util.get_boxspat(meta,i,d,rmin,rmax,cmin,cmax,11) #row_spat is always np.linspace(rmin,rmax+1,(rmax-rmin)*1000)
+                row_spat, flux_spat = util.get_boxspat(meta,i,d,rmin,rmax,cmin,cmax,(d[0].header['nsamp']-1)*5+1) #row_spat is always np.linspace(rmin,rmax+1,(rmax-rmin)*1000)
                 # NOTE: determine rowshift and store it in meta
                 if i == 0:
                     #initialize arrays

--- a/src/pacman/s20_extract.py
+++ b/src/pacman/s20_extract.py
@@ -207,7 +207,7 @@ def run20(eventlabel, workdir: Path, meta=None):
                     if i == 0:
                         #initialize arrays
                         meta.refprofile_stretch = np.zeros((2,len(row_spat)))
-                        meta.stretch = np.zeros(meta.nexp)
+                        meta.stretch = np.ones(meta.nexp)
 
                     if i < 2:
                         #store reference profiles of the first exposures

--- a/src/pacman/s20_extract.py
+++ b/src/pacman/s20_extract.py
@@ -182,6 +182,41 @@ def run20(eventlabel, workdir: Path, meta=None):
                 var_box += var_box_0
 
         elif len(set(meta.scans_sp)) == 2:
+            # NOTE: If needed: Calculate spectrum shift in spatial direction (rows) with respect to the first exposure in the data-set (i.e. first visit, first orbit, first exposure)
+            if meta.calculate_rowshift:
+                #get spatial profile of exposure of first readout
+                row_spat, flux_spat = get_boxspat(meta,i,d,rmin,rmax,cmin,cmax,11) #row_spat is always np.linspace(rmin,rmax+1,(rmax-rmin)*1000)
+                # NOTE: determine rowshift and store it in meta
+                if i == 0:
+                    #initialize arrays
+                    meta.refprofile_rowshift = np.zeros((2,len(rows_spat)))
+                    meta.rowshift = np.zeros(meta.nexp)
+
+                if i < 2:
+                    #store reference profiles of the first exposures
+                    meta.refprofile_rowshift[meta.scans_sp[i]] = flux_spat    
+                else:
+                    #fit spatial profiles to reference profiles
+                    rowshift_exp = calculate_rowshift(meta,row_spat, meta.refprofile_rowshift[meta.scans_sp[i]],row_spat[10000:-10000], flux_spat[10000:-10000],i):  
+                    meta.rowshift[i] = rowshift_exp
+                
+                # NOTE: calculate stretch of last readout with respect to first exposure in the data-set 
+                if save_rowshift_stretch_plot or show_rowshift_stretch_plot:
+                    row_spat, flux_spat = get_boxspat(meta,i,d,rmin,rmax,cmin,cmax,1) #row_spat is always np.linspace(rmin,rmax+1,(rmax-rmin)*1000)
+                    # NOTE: determine rowshift and store it in meta
+                    if i == 0:
+                        #initialize arrays
+                        meta.refprofile_stretch = np.zeros((2,len(rows_spat)))
+                        meta.stretch = np.zeros(meta.nexp)
+
+                    if i < 2:
+                        #store reference profiles of the first exposures
+                        meta.refprofile_stretch[meta.scans_sp[i]] = flux_spat    
+                    else:
+                        #fit spatial profiles to reference profiles
+                        stretch_exp = calculate_stretch(meta,row_spat, meta.refprofile_stretch[meta.scans_sp[i]],row_spat[10000:-10000], flux_spat[10000:-10000],i):  
+                        meta.stretch[i] = stretch_exp
+
             for ii in tqdm(np.arange(d[0].header['nsamp']-2, dtype=int), desc='--- Looping over up-the-ramp-samples', leave=True, position=0):
                 diff = d[ii*5 + 1].data[rmin:rmax,cmin:cmax] - d[ii*5 + 6].data[rmin:rmax,cmin:cmax]    # Creates image that is the difference between successive scans
 
@@ -314,6 +349,9 @@ def run20(eventlabel, workdir: Path, meta=None):
 
     if meta.save_drift_plot or meta.show_drift_plot:
         plots.drift(leastsq_res_all, meta)
+
+    if save_rowshift_stretch_plot or show_rowshift_stretch_plot:
+        plots.rowshift_stretch(meta)
 
     print('Finished s20 \n')
     return meta

--- a/src/pacman/s20_extract.py
+++ b/src/pacman/s20_extract.py
@@ -185,11 +185,11 @@ def run20(eventlabel, workdir: Path, meta=None):
             # NOTE: If needed: Calculate spectrum shift in spatial direction (rows) with respect to the first exposure in the data-set (i.e. first visit, first orbit, first exposure)
             if meta.calculate_rowshift:
                 #get spatial profile of exposure of first readout
-                row_spat, flux_spat = get_boxspat(meta,i,d,rmin,rmax,cmin,cmax,11) #row_spat is always np.linspace(rmin,rmax+1,(rmax-rmin)*1000)
+                row_spat, flux_spat = util.get_boxspat(meta,i,d,rmin,rmax,cmin,cmax,11) #row_spat is always np.linspace(rmin,rmax+1,(rmax-rmin)*1000)
                 # NOTE: determine rowshift and store it in meta
                 if i == 0:
                     #initialize arrays
-                    meta.refprofile_rowshift = np.zeros((2,len(rows_spat)))
+                    meta.refprofile_rowshift = np.zeros((2,len(row_spat)))
                     meta.rowshift = np.zeros(meta.nexp)
 
                 if i < 2:
@@ -197,16 +197,16 @@ def run20(eventlabel, workdir: Path, meta=None):
                     meta.refprofile_rowshift[meta.scans_sp[i]] = flux_spat    
                 else:
                     #fit spatial profiles to reference profiles
-                    rowshift_exp = calculate_rowshift(meta,row_spat, meta.refprofile_rowshift[meta.scans_sp[i]],row_spat[10000:-10000], flux_spat[10000:-10000],i)
+                    rowshift_exp = util.calculate_rowshift(meta,row_spat, meta.refprofile_rowshift[meta.scans_sp[i]],row_spat[10000:-10000], flux_spat[10000:-10000],i)
                     meta.rowshift[i] = rowshift_exp
                 
                 # NOTE: calculate stretch of last readout with respect to first exposure in the data-set 
-                if save_rowshift_stretch_plot or show_rowshift_stretch_plot:
-                    row_spat, flux_spat = get_boxspat(meta,i,d,rmin,rmax,cmin,cmax,1) #row_spat is always np.linspace(rmin,rmax+1,(rmax-rmin)*1000)
+                if meta.save_rowshift_stretch_plot or meta.show_rowshift_stretch_plot:
+                    row_spat, flux_spat = util.get_boxspat(meta,i,d,rmin,rmax,cmin,cmax,1) #row_spat is always np.linspace(rmin,rmax+1,(rmax-rmin)*1000)
                     # NOTE: determine rowshift and store it in meta
                     if i == 0:
                         #initialize arrays
-                        meta.refprofile_stretch = np.zeros((2,len(rows_spat)))
+                        meta.refprofile_stretch = np.zeros((2,len(row_spat)))
                         meta.stretch = np.zeros(meta.nexp)
 
                     if i < 2:
@@ -214,7 +214,7 @@ def run20(eventlabel, workdir: Path, meta=None):
                         meta.refprofile_stretch[meta.scans_sp[i]] = flux_spat    
                     else:
                         #fit spatial profiles to reference profiles
-                        stretch_exp = calculate_stretch(meta,row_spat, meta.refprofile_stretch[meta.scans_sp[i]],row_spat[10000:-10000], flux_spat[10000:-10000],i)  
+                        stretch_exp = util.calculate_stretch(meta,row_spat, meta.refprofile_stretch[meta.scans_sp[i]],row_spat[10000:-10000], flux_spat[10000:-10000],i)  
                         meta.stretch[i] = stretch_exp
 
             for ii in tqdm(np.arange(d[0].header['nsamp']-2, dtype=int), desc='--- Looping over up-the-ramp-samples', leave=True, position=0):
@@ -350,7 +350,7 @@ def run20(eventlabel, workdir: Path, meta=None):
     if meta.save_drift_plot or meta.show_drift_plot:
         plots.drift(leastsq_res_all, meta)
 
-    if save_rowshift_stretch_plot or show_rowshift_stretch_plot:
+    if meta.save_rowshift_stretch_plot or meta.show_rowshift_stretch_plot:
         plots.rowshift_stretch(meta)
 
     print('Finished s20 \n')

--- a/src/pacman/s20_extract.py
+++ b/src/pacman/s20_extract.py
@@ -197,7 +197,7 @@ def run20(eventlabel, workdir: Path, meta=None):
                     meta.refprofile_rowshift[meta.scans_sp[i]] = flux_spat    
                 else:
                     #fit spatial profiles to reference profiles
-                    rowshift_exp = calculate_rowshift(meta,row_spat, meta.refprofile_rowshift[meta.scans_sp[i]],row_spat[10000:-10000], flux_spat[10000:-10000],i):  
+                    rowshift_exp = calculate_rowshift(meta,row_spat, meta.refprofile_rowshift[meta.scans_sp[i]],row_spat[10000:-10000], flux_spat[10000:-10000],i)
                     meta.rowshift[i] = rowshift_exp
                 
                 # NOTE: calculate stretch of last readout with respect to first exposure in the data-set 
@@ -214,7 +214,7 @@ def run20(eventlabel, workdir: Path, meta=None):
                         meta.refprofile_stretch[meta.scans_sp[i]] = flux_spat    
                     else:
                         #fit spatial profiles to reference profiles
-                        stretch_exp = calculate_stretch(meta,row_spat, meta.refprofile_stretch[meta.scans_sp[i]],row_spat[10000:-10000], flux_spat[10000:-10000],i):  
+                        stretch_exp = calculate_stretch(meta,row_spat, meta.refprofile_stretch[meta.scans_sp[i]],row_spat[10000:-10000], flux_spat[10000:-10000],i)  
                         meta.stretch[i] = stretch_exp
 
             for ii in tqdm(np.arange(d[0].header['nsamp']-2, dtype=int), desc='--- Looping over up-the-ramp-samples', leave=True, position=0):

--- a/tests/run_files/fit_par.txt
+++ b/tests/run_files/fit_par.txt
@@ -13,7 +13,10 @@ ecc           True    -1     0.0         False     0.0       False    0.0      X
 c             False   -1     6.37        True      6.0       True     9.0      U       6.0       9.0      0.01          
 v             True    -1     -1e-06      False     -0.0001   False    -1e-08   X       -7e-06    -1e-06   1e-05          
 v2            True    -1     0.0         False     0.0       False    1.0      X       0.0       0.0      1e-11      
+rowshift_vr   True    -1     0.0         False    -10.0     False    10.0     U       -1.0      1.0      1e-07      
+rowshift_vf   True    -1     0.0         False    -10.0     False    10.0     U       -1.0      1.0      1e-07 
 r1            True    -1     0.          False     0.0       False    1.0      X       -10.0     10.0     0.01       
 r2            True    -1     0.0         False     5.5       False    7.5      X       -100.0    100.0    0.1        
 r3            True    -1     0.0         False     -1.0      False    1.0      X       -10.0     10.0     0.001      
 scale         True    -1     0.0         False     -0.01     False    0.01     X       -0.1      0.1      0.002             
+uncmulti_val  True    -1     1.0         False    1.0       False    7.0      U       0.1       10.0     0.01       

--- a/tests/run_files/obs_par.pcf
+++ b/tests/run_files/obs_par.pcf
@@ -69,6 +69,14 @@ bg_rmax                      400
 bg_cmin                      40
 bg_cmax                      100
 
+calculate_rowshift           True                                            # calculates spatial shift of spectrum on detector with respect to first exposure
+
+save_rowshift_plot           True                                             # save plot of rowshift fit
+show_rowshift_plot           False
+
+save_rowshift_stretch_plot   True                                             # save plot of stretch fit and plot of profile stretch to rowshift
+show_rowshift_stretch_plot   False
+
 save_optextr_plot            True
 
 save_sp2d_plot               True                                               # save plot of 2d spectrum


### PR DESCRIPTION
**MCMC for multiple visits** (applied these changes also for nested sampling, but may not be sufficient to fix nested):

**Files:** mcmc , nested , util
**What?** util.format_params_for_Model now alters the parameters of all visits in updated_params. Therefore, model.fit now considers all visits.

---------
**applied uncmulti_val to error**

**Files:** mcmc, nested
**What?** uncmulti_val was previously only applied during sampling, but the final uncmulti_val was not applied on the errors. It is now.

---------
**added model model_rowshift**

**Files:** fit_par, obs_par, plots, formatter, functions, model_rowshift (new), read_data, util, s20_extract
**What?** Added new systematics model that may be needed for fast scans of bright stars. In s20_extract, it measures the vertical (rows) position of the spectrum of all exposures (based on the first non-destructive exposure) with respect to the spectrum-position of the first exposure in the data (rowshift). This rowshift is stored in meta and some diagnostics plots can be saved if needed. In s30, the new function "model_rowshift" fits linear slopes as a function of rowshift to the forward and reverse scans in the data. 
I tried to leave the runtime of PACMAN mostly unchanged if the function is not used.